### PR TITLE
Update king-of-fans-zigbee-fan-controller.groovy

### DIFF
--- a/devicetypes/rafaelborja/king-of-fans-zigbee-fan-controller.src/king-of-fans-zigbee-fan-controller.groovy
+++ b/devicetypes/rafaelborja/king-of-fans-zigbee-fan-controller.src/king-of-fans-zigbee-fan-controller.groovy
@@ -547,17 +547,14 @@ def speedToDimmerLevel(speed) {
 
 /**
  * Returns a fan value for a given dimmer value
- *  - 0 to 18 is speed 0 (turn off)
- *  - 20 to 39 is speed 1 (low)
- *  - 40 to 59 is speed 2 (medium)
- *  - 60 to 79 is speed 3 (medium-high)
- *  - 80 to 100 is speed 4 (high)
+ *  - 0 to 20 is speed 0 (turn off)
+ *  - 21 to 40 is speed 1 (low)
+ *  - 41 to 60 is speed 2 (medium)
+ *  - 61 to 80 is speed 3 (medium-high)
+ *  - 81 to 100 is speed 4 (high)
  */
-def dimmerLevelToSpeed(dimmerLevel) {
-	if (dimmerLevel == null) {
-    	dimmerLevel = 0
-    }
-	return  Math.round(dimmerLevel/20)
+def dimmerLevelToSpeed(dimmerLevel) { 
+	return  (Math.floor(dimmerLevel/20.04) as Integer)
 }
 
 


### PR DESCRIPTION
Since round() will round to the nearest integer (up or down), your 25%, 50%, 75%, 100% was resulting in values of 1, 3, 4, 5, respectively. The code I'm proposing here should fix that (I believe floor will return 0 if you pass null into it, so I got rid of that check as well).